### PR TITLE
FIX computation of scores by label

### DIFF
--- a/attelo/score.py
+++ b/attelo/score.py
@@ -136,14 +136,13 @@ def score_edges_by_label(dpack, predictions):
     """
     predictions = [(e1, e2, r) for (e1, e2, r) in predictions
                    if r != UNRELATED]
-    unrelated = dpack.label_number(UNRELATED)
 
-    for target in dpack.target:
-        if target == unrelated:
+    for label in dpack.labels:
+        if label == UNRELATED:
             continue
-        label = dpack.get_label(target)
+        label_num = dpack.label_number(label)
         # pylint: disable=no-member
-        r_indices = numpy.where(dpack.target == target)[0]
+        r_indices = numpy.where(dpack.target == label_num)[0]
         # pylint: disable=no-member
         r_dpack = dpack.selected(r_indices)
         r_predictions = [(e1, e2, r) for (e1, e2, r) in predictions


### PR DESCRIPTION
This PR fixes the computation of scores by label, if I understand the intended semantics of the function correctly.
The erroneous code had the effect of repeating label counts as many times as the number of occurrences of the label in the reference, which led to the very high counts reported by @kowey .