### PR TITLE
ENH new baseline decoder, takes top N edges, N=nb(edus)

### DIFF
--- a/attelo/decoding/__init__.py
+++ b/attelo/decoding/__init__.py
@@ -77,6 +77,13 @@ def _mk_local_decoder(config, default=0.5):
     return LocalBaseline(threshold, config.use_prob)
 
 
+def _mk_asmany_decoder(config):
+    """
+    Instantiate the local "as many" decoder
+    """
+    return LocalBaselineAsMany(threshold, config.use_prob)
+
+
 def _mk_mst_decoder(config):
     """
     Instantiate an MST decoder
@@ -87,6 +94,7 @@ def _mk_mst_decoder(config):
 
 DECODERS = {"last": lambda _: LastBaseline(),
             "local": _mk_local_decoder,
+            "asmany": _mk_asmany_decoder,
             "locallyGreedy": lambda _: LocallyGreedy(),
             "msdag": lambda c: MsdagDecoder(c.mst_root_strategy, c.use_prob),
             "mst": _mk_mst_decoder,

--- a/attelo/decoding/baseline.py
+++ b/attelo/decoding/baseline.py
@@ -24,6 +24,24 @@ class LocalBaseline(Decoder):
         return [predicted]
 
 
+class LocalBaselineAsMany(Decoder):
+    """just attach locally the top N edges, N=nb(real EDUs)"""
+    def decode(self, prob_distrib):
+        """Predict as many labels as there are EDUs"""
+        # assume all real EDUs appear as a2 in prob_distrib
+        nb_edus = len(list(set(a2 for a1, a2, p, l in prob_distrib)))
+
+        predicted = []
+        sorted_cands = sorted(prob_distrib, key=lambda t: t[2], reverse=True)
+        for arg1, arg2, probs, label in sorted_cands:
+            attach = probs
+            if len(predicted) < nb_edus:
+                predicted.append((arg1.id, arg2.id, label))
+            else:
+                break
+        return [predicted]
+
+
 class LastBaseline(Decoder):
     "attach to last, always"
 


### PR DESCRIPTION
This PR is a quick n dirty implementation of a baseline decoder that takes the top N edges from the initial graph, with N the number of real EDUs in the document.
On `RST-double`, this baseline decoder is quite challenging, with scores just inferior to `MST`.
Compared to `local`, this decoder has the advantage of being parameter-free (no tuning required).

Another baseline decoder that would be worth writing is the one that takes, for each real EDU, the highest scored incoming edge. The output structure might not be a tree.
This would be another non-parametric baseline decoder, probably challenging too.