### PR TITLE
ENH new local decoders: asmany and bestin

### DIFF
--- a/attelo/decoding/__init__.py
+++ b/attelo/decoding/__init__.py
@@ -28,6 +28,7 @@ from .astar import (AstarDecoder)
 from .baseline import LastBaseline, LocalBaseline
 from .mst import (MsdagDecoder, MstDecoder, MstRootStrategy)
 from .greedy import LocallyGreedy
+from .local import (AsManyDecoder, BestIncomingDecoder)
 
 
 class DecoderArgs(namedtuple("DecoderAgs",
@@ -90,7 +91,10 @@ DECODERS = {"last": lambda _: LastBaseline(),
             "locallyGreedy": lambda _: LocallyGreedy(),
             "msdag": lambda c: MsdagDecoder(c.mst_root_strategy, c.use_prob),
             "mst": _mk_mst_decoder,
-            "astar": lambda c: AstarDecoder(c.astar)}
+            "astar": lambda c: AstarDecoder(c.astar),
+            "asmany": lambda _: AsManyDecoder(),
+            "bestin": lambda _: BestIncomingDecoder(),
+}
 """
 Dictionary (`string -> DecoderAgs -> Decoder`) of decoder names (recognised by
 the command line interface) to wrappers. Wrappers smooth out the differences

--- a/attelo/decoding/local.py
+++ b/attelo/decoding/local.py
@@ -1,0 +1,73 @@
+"""
+Local decoders make decisions for each edge independently.
+"""
+
+from collections import defaultdict
+
+from .interface import Decoder
+
+
+class AsManyDecoder(Decoder):
+    """Greedy decoder that picks as many edges as there are real EDUs.
+
+    The output structure is a graph that has the same number of edges
+    as a spanning tree over the EDUs.
+    It can be non-connex, contain cycles and re-entrancies.
+    """
+
+    def decode(self, cands):
+        """Return the set of top N edges
+
+        Parameters
+        ----------
+        cands: iterable
+            candidate set
+        """
+        # number of real EDUs
+        # this works under the assumption that all real EDUs appear
+        # as targets in cands
+        nb_edus = len(set(tgt for src, tgt, score, lbl in cands))
+        # sort candidates by their scores (in reverse order)
+        sorted_cands = sorted(cands, key=lambda c: c[2], reverse=True)
+        # take the top N candidates, where N is the number of real EDUs
+        predicted = [(src.id, tgt.id, lbl)
+                     for src, tgt, score, lbl in sorted_cands[:nb_edus]]
+
+        return [predicted]
+
+
+class BestIncomingDecoder(Decoder):
+    """Greedy decoder that picks the best incoming edge for each EDU.
+    
+    The output structure is a graph that contains exactly one incoming
+    edge for each EDU, thus it has the same number of edges as a
+    spanning tree over the EDUs.
+    It can be non-connex or contain cycles, but no re-entrancy.
+    """
+
+    def decode(self, cands):
+        """Return the best incoming edge for each EDU
+
+        Parameters
+        ----------
+        cands: iterable
+            candidate set
+        """
+        # best incoming edge for each EDU
+        inc_edges = {}
+        for cand in cands:
+            src, tgt, score, lbl = cand
+            try:
+                cur_best = inc_edges[tgt.id][2]
+            except KeyError:
+                # tgt is yet unseen
+                inc_edges[tgt.id] = cand
+            else:
+                if score > cur_best:
+                    inc_edges[tgt.id] = cand
+
+        predicted = [(src.id, tgt.id, lbl)
+                     for src, tgt, score, lbl in inc_edges.values()]
+
+        return [predicted]
+    

--- a/attelo/decoding/local.py
+++ b/attelo/decoding/local.py
@@ -57,14 +57,12 @@ class BestIncomingDecoder(Decoder):
         inc_edges = {}
         for cand in cands:
             src, tgt, score, lbl = cand
-            try:
+            if tgt.id in inc_edges:
                 cur_best = inc_edges[tgt.id][2]
-            except KeyError:
-                # tgt is yet unseen
-                inc_edges[tgt.id] = cand
-            else:
                 if score > cur_best:
                     inc_edges[tgt.id] = cand
+            else:
+                inc_edges[tgt.id] = cand
 
         predicted = [(src.id, tgt.id, lbl)
                      for src, tgt, score, lbl in inc_edges.values()]


### PR DESCRIPTION
This PR adds two greedy local decoders that integrate different constraints than `LocalBaseline`:
* `AsManyDecoder` greedily takes as many of the best edges as there are EDUs ;
* `BestIncomingDecoder` greedily takes the best incoming edge for each EDU.

On RST-double, their level of performance approaches MST's.
MST keeps an advantage on finding the root (there is no constraint on having a root in either baseline decoder) and on inter-sentence relations.
I don't think they should always be included in our benchmarks, but they can provide good insight in finding where global decoders have an edge.